### PR TITLE
Fix black whiteboard

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ RUN apt-get install -qy curl iceweasel sudo desktop-file-utils lib32z1 \
   libfontconfig1 libpulse0 libsqlite3-0 \
   libxcb-shape0 libxcb-xfixes0 libxcb-randr0 libxcb-image0 \
   libxcb-keysyms1 libxcb-xtest0 ibus ibus-gtk \
-  libnss3 libxss1
+  libnss3 libxss1 xcompmgr
 
 ARG ZOOM_URL=https://zoom.us/client/latest/zoom_amd64.deb
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -53,6 +53,7 @@ grant_access_to_video_devices() {
 
 launch_zoom_us() {
   cd /home/${ZOOM_US_USER}
+  exec sudo -HEu ${ZOOM_US_USER} PULSE_SERVER=/run/pulse/native QT_GRAPHICSSYSTEM="native" xcompmgr -c -l0 -t0 -r0 -o.00 &
   exec sudo -HEu ${ZOOM_US_USER} PULSE_SERVER=/run/pulse/native QT_GRAPHICSSYSTEM="native" $@
 }
 


### PR DESCRIPTION
Sharing a whiteboard didn't work. The whiteboard showed up black and you
couldn't see anything being drawn on it. Running xcompmgr solved it.

A little bit of more information:
https://support.zoom.us/hc/en-us/articles/202082128-Black-Screen-During-Screen-Sharing